### PR TITLE
Implemented query system that uses event ID rather than sncl

### DIFF
--- a/fdsn_plot.py
+++ b/fdsn_plot.py
@@ -6,11 +6,12 @@ import sys
 import subprocess
 from obspy import UTCDateTime
 from obspy.clients.fdsn import Client
+from obspy import Stream
 import matplotlib.pyplot as plt
 
 
-DEFAULT_SNCL = "IU.ANMO.00.BHZ"
-DEFAULT_HOURS = 1
+DEFAULT_ID = "12060740"
+DEFAULT_MINUTES = 10
 DEFAULT_CLIENT = "IRIS"
 
 
@@ -34,108 +35,134 @@ def open_image(path):
     except Exception as e:
         print(f"Could not open image automatically: {e}")
 
+def get_event_info(client, event_id):
+    catalog = client.get_events(eventid = event_id)
+    event = catalog[0]
+    origin = event.preferred_origin() or event.origins[0]
 
-
-def parse_sncl(sncl):
-    """Split SNCL string into components."""
-    try:
-        net, sta, loc, cha = sncl.split(".")
-        return net, sta, loc, cha
-    except ValueError:
-        raise ValueError("SNCL must be in NET.STA.LOC.CHA format")
-
+    return origin.time, origin.latitude, origin.longitude
 
 def main():
     parser = argparse.ArgumentParser(
         description="Query FDSN data and plot waveform to PNG"
     )
     parser.add_argument(
-        "--sncl",
-        help="SNCL code (NET.STA.LOC.CHA)",
-        default=DEFAULT_SNCL,
+        "--eventid",
+        help = "FDSN Event ID (e.g. 11843205)",
+        default = DEFAULT_ID
     )
     parser.add_argument(
-        "--hours",
-        type=float,
-        default=DEFAULT_HOURS,
-        help="Hours of data to fetch (default: 1)",
+        "--radius",
+        type = float,
+        default = 1.0,
+        help = "Search radius in degrees around epicenter"
     )
     parser.add_argument(
-        "--interactive",
-        action="store_true",
-        help="Prompt for SNCL and time window",
+        "--channel",
+        default = "BHZ",
+        help = "Seismic channel to fetch (default: BHZ)"
     )
     parser.add_argument(
         "--client",
         default=DEFAULT_CLIENT,
         help="FDSN client name (default: IRIS)",
     )
+    parser.add_argument(
+        "--minutes",
+        type=float,
+        default=DEFAULT_MINUTES,
+        help="Minutes of data to fetch (default: 10)",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Prompt for SNCL and time window",
+    )
 
     args = parser.parse_args()
 
     # Interactive overrides
     if args.interactive:
-        sncl = input(f"SNCL [{DEFAULT_SNCL}]: ").strip() or DEFAULT_SNCL
-        hours = input(f"Hours [{DEFAULT_HOURS}]: ").strip()
-        hours = float(hours) if hours else DEFAULT_HOURS
-    else:
-        sncl = args.sncl
-        hours = args.hours
-
-    net, sta, loc, cha = parse_sncl(sncl)
-
-    # Time window
-    endtime = UTCDateTime.now()
-    starttime = endtime - hours * 3600
-
-    print(f"Querying {sncl}")
-    print(f"Time window: {starttime} → {endtime}")
+        args.eventid = input(f"Enter an Event ID default: [{args.eventid}]: ").strip() or args.eventid
+        
+        radius_input = input(f"Enter Search Radius default: [{args.radius}]: ").strip()
+        args.radius = float(radius_input) if radius_input else args.radius
+        
+        args.channel = input(f"Enter Channel default: [{args.channel}]: ").strip() or args.channel
+        
+        minutes_input = input(f"Enter Minutes default: [{args.minutes}]: ").strip()
+        args.minutes = float(minutes_input) if minutes_input else args.minutes
 
     client = Client(args.client)
 
-    try:
-        st = client.get_waveforms(
-            network=net,
-            station=sta,
-            location=loc,
-            channel=cha,
-            starttime=starttime,
-            endtime=endtime,
-        )
-    except Exception as e:
-        print(f"Error fetching data: {e}")
-        sys.exit(1)
+    print(f"--- Fetching Event {args.eventid} ---")
+    ev_time, ev_lat, ev_long = get_event_info(client, args.eventid)
 
-    if len(st) == 0:
-        print("No data returned.")
-        sys.exit(1)
+    #Time starts five minutes before event
+    starttime = ev_time - 300
+    endtime = ev_time + (args.minutes * 60)
 
-    # Prepare data
-    st.merge()
-    st.detrend("demean")
-    st.detrend("linear")
+    print(f"Searching stations within {args.radius} degrees...")
 
-    tr = st[0]
+    inventory = client.get_stations(
+        latitude=ev_lat, 
+        longitude=ev_long, 
+        maxradius=args.radius, 
+        level="station"
+    )
 
-    times = tr.times("matplotlib")
-    data = tr.data
+    all_data = Stream()
 
-    # Plot
-    fig, ax = plt.subplots(figsize=(10, 4))
-    ax.plot(times, data, "-", linewidth=0.8)
+    excluded_networks = ['SY', '9M', 'XE', 'NP', 'GM', 'YM', 'Z5', 'YG']
 
-    ax.set_title(tr.id)
-    ax.set_xlabel("Time (UTC)")
+    for network in inventory:
+        # Certain networks will be identified but the data not publicly accessible so just skip them
+        # You may see requests to networks not included, if they don't show on the graph they can probably be excluded
+        if network.code in excluded_networks:
+            continue
+        for station in network:
+            print(f"Requesting {network.code}.{station.code}...")
+            try:
+                st = client.get_waveforms(
+                    network=network.code,
+                    station=station.code,
+                    location="*",
+                    channel=args.channel,
+                    starttime=starttime,
+                    endtime=endtime,
+                )
+                all_data += st
+            except Exception:
+                continue
+
+    if not all_data:
+        print("No waveform data found for the given parameters.")
+        return
+
+    # Processing
+    all_data.merge(method=1, fill_value='interpolate')
+    all_data.detrend("demean")
+    all_data.detrend("linear")
+    all_data.taper(max_percentage=0.05)
+
+    # Plotting
+    plt.style.use('ggplot')
+    fig, ax = plt.subplots(figsize=(12, 6))
+    
+    for tr in all_data:
+        ax.plot(tr.times("matplotlib"), tr.data, label=tr.id, lw=1)
+
+    ax.set_title(f"Event {args.eventid} Comparison | Channel: {args.channel}")
     ax.set_ylabel("Counts")
-
+    ax.xaxis_date()
     fig.autofmt_xdate()
+    ax.legend(loc='upper right', fontsize='small', ncol=2)
 
-    out_png = f"{sncl.replace('.', '_')}.png"
-    fig.savefig(out_png, dpi=150, bbox_inches="tight")
+    out_png = f"event_{args.eventid}_comparison.png"
+    plt.savefig(out_png, dpi=150, bbox_inches="tight")
     plt.close(fig)
 
-
-    print(f"Saved plot to {out_png}")
+    print(f"Success! Saved to {out_png}")
     open_image(out_png)
 
 


### PR DESCRIPTION
Refs #1 

Changes logic to use an event ID rather than sncl to query stations in a range around the events location, and then plots waveforms from those stations.

Verified on local machine, works in interactive mode or with fully default options, see description for #1 for info on finding other event ID's to test with, also be aware that large search radii will take a while

